### PR TITLE
making it so you can use non standard piwik .php scripts (iOS)

### DIFF
--- a/ios/PiwikTracker/PiwikTracker.m
+++ b/ios/PiwikTracker/PiwikTracker.m
@@ -221,23 +221,21 @@ static PiwikTracker *_sharedInstance;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-
 + (instancetype)sharedInstanceWithSiteID:(NSString*)siteID baseURL:(NSURL*)baseURL {
-  
-  // Make sure the base url is correct
+
   NSString *lastPathComponent = [baseURL lastPathComponent];
-  if ([lastPathComponent isEqualToString:@"piwik.php"] || [lastPathComponent isEqualToString:@"piwik-proxy.php"]) {
-    baseURL = [baseURL URLByDeletingLastPathComponent];
+  if (lastPathComponent && lastPathComponent.length) {
+    baseURL = [baseURL URLByDeletingLastPathComponent];  
   }
-  
-  return [self sharedInstanceWithSiteID:siteID dispatcher:[self defaultDispatcherWithPiwikURL:baseURL]];
+
+  return [self sharedInstanceWithSiteID:siteID dispatcher:[self defaultDispatcherWithPiwikURL:baseURL lastPathComponent:lastPathComponent]];
 }
 
 
-+ (id<PiwikDispatcher>)defaultDispatcherWithPiwikURL:(NSURL*)piwikURL {
-  
-  NSURL *endpoint = [[NSURL alloc] initWithString:@"piwik.php" relativeToURL:piwikURL];
-  
++ (id<PiwikDispatcher>)defaultDispatcherWithPiwikURL:(NSURL*)piwikURL lastPathComponent:(NSString*)lastPathComponent {
+
+  NSURL *endpoint = [[NSURL alloc] initWithString:lastPathComponent relativeToURL:piwikURL];
+
   // Instantiate dispatchers in priority order
   if (NSClassFromString(@"PiwikAFNetworking2Dispatcher")) {
     return [[NSClassFromString(@"PiwikAFNetworking2Dispatcher") alloc] initWithPiwikURL:endpoint];
@@ -246,7 +244,7 @@ static PiwikTracker *_sharedInstance;
   } else {
     return [[PiwikNSURLSessionDispatcher alloc] initWithPiwikURL:endpoint];
   }
-  
+
 }
 
 


### PR DESCRIPTION
Hey guys great library,

So we are building an iOS app in react-native and are using piwik as an analytics platform. We are also using a non standard url pattern for the tracker (Or url ends in `p.php` instead of `piwik.php`). Because of this, we had to change the code in this repo so that we can use the library. 

I was wondering if there was any innate reason that you knew of why the tracker must end with `piwik.php`. I see that [official matamo ios sdk](https://github.com/matomo-org/matomo-sdk-ios/blob/88fe21e63aa10f2216aed8eaecc6bc3225aa2e20/PiwikTracker/PiwikTracker.swift#L79) does the same thing. If not, this should be an easy way to make it so that one could use a tracking url that does not end in `piwik.php`.

Cheers,
Alex