### PR TITLE
Add safeExtGet to gradle library version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion safeExtGet("compileSdkVersion", 25)
+    buildToolsVersion safeExtGet("buildToolsVersion", '25.0.2')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 25)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
I have issue with compileversion 25, because I use 28 for new react native library.

So I add safeExtGet wrapper to get version from project version