### PR TITLE
Add React-Core dependency podspec

### DIFF
--- a/BNFMatomo.podspec
+++ b/BNFMatomo.podspec
@@ -14,4 +14,7 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/{BNFMatomo,MatomoTracker}/**/*.{m,h,swift}"
   s.static_framework = true
   s.swift_version = '4.2'
+  
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
This is required for RN 0.63.3 since the `React` umbrella pod will be deprecated. Without this you'll get a build error because Xcode 12 treats this like an Objective-C pod