### PR TITLE
Add safeextget method

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion safeExtGet("compileSdkVersion", 29)
+    buildToolsVersion safeExtGet("buildToolsVersion", "29.0.2")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion safeExtGet("minSdkVersion", 19)
+        targetSdkVersion safeExtGet("targetSdkVersion", 29)
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 29)
     buildToolsVersion safeExtGet("buildToolsVersion", "29.0.2")


### PR DESCRIPTION
Added a safeExtGet method to allow support for the developer's defined compileSdkVersion, buildToolsVersion, minSdkVersion and targetSdkVersion and using the minimum permissible versions as fallback.